### PR TITLE
Typo mistake on selectSrcLanguageWarning

### DIFF
--- a/i18n/tmxeditor_en.json
+++ b/i18n/tmxeditor_en.json
@@ -222,7 +222,7 @@
         "selectLanguageWarning": "Select new language"
     },
     "newFile": {
-        "selectsrcLanguageWarning": "Select source language",
+        "selectSrcLanguageWarning": "Select source language",
         "selectTgtLanguageWarning": "Select target language",
         "selectDifferentLanguages": "Select different languages"
     },

--- a/i18n/tmxeditor_es.json
+++ b/i18n/tmxeditor_es.json
@@ -116,7 +116,7 @@
   "newFile": {
     "selectTgtLanguageWarning": "Seleccione idioma destino",
     "selectDifferentLanguages": "Seleccione idiomas diferentes",
-    "selectsrcLanguageWarning": "Seleccione idioma origen"
+    "selectSrcLanguageWarning": "Seleccione idioma origen"
   },
   "fileInfo": {
     "creationtool": "Herramienta de Creación es obligatorio",


### PR DESCRIPTION
In newFile section, replace selectsrcLanguageWarning with selectSrcLanguageWarning

This pull request solves issue #12 