### PR TITLE
Internationalize Attribute Setting popup window title

### DIFF
--- a/ts/app.ts
+++ b/ts/app.ts
@@ -288,6 +288,11 @@ class App {
         ipcMain.on('get-unit-attributes', (event: IpcMainEvent) => {
             event.sender.send('set-unit-attributes', App.attributesArg);
         });
+        ipcMain.on('get-lang-attributes-text', (event: IpcMainEvent) => {
+            let attributesArg = App.attributesArg;
+            let attributesLabel: string = App.i18n.getString('App', 'langAttributes');
+            event.sender.send('set-lang-attributes-text', App.i18n.format(attributesLabel, [attributesArg.type]));
+        });
         ipcMain.on('save-attributes', (event: IpcMainEvent, arg: any) => {
             this.saveAttributes(arg);
         });

--- a/ts/attributes.ts
+++ b/ts/attributes.ts
@@ -16,6 +16,7 @@ class Attributes {
 
     currentId: string;
     currentType: string;
+    langAttributesText: string = 'Attributes';
 
     constructor() {
         this.electron.ipcRenderer.send('get-theme');
@@ -40,13 +41,19 @@ class Attributes {
                 this.electron.ipcRenderer.send('close-attributes');
             }
         });
+        this.electron.ipcRenderer.send('get-lang-attributes-text');
+        this.electron.ipcRenderer.on('set-lang-attributes-text', (event: Electron.IpcRendererEvent, text: string) => {
+            this.langAttributesText = text;
+        });
         this.electron.ipcRenderer.send('attributes-height', { width: document.body.clientWidth, height: document.body.clientHeight });
     }
 
     setUnitAttributes(arg: any): void {
         this.currentId = arg.id;
         this.currentType = arg.type;
-        document.getElementById('title').innerHTML = this.currentType + ' Attributes';
+        if (this.currentType !== 'TU') {
+            document.getElementById('title').innerHTML = this.langAttributesText;
+        }
 
         let attributes: Array<string[]> = arg.atts;
         for (let pair of attributes) {


### PR DESCRIPTION
This will solve issue #14:
- For translation unit attributes, show the title located in the (localized) attributes.html file
- For language specific attributes, use the langAttributes string localized in i18n/tmxeditor_xx.json

**App in Spanish / TU Attributes**
<img width="915" height="241" alt="image" src="https://github.com/user-attachments/assets/1b98d071-ea5f-4d95-9e0a-834330877aef" />

**App in Spanish / Language-specific Attributes**
<img width="919" height="228" alt="image" src="https://github.com/user-attachments/assets/ca91fb14-6ec7-454a-8dd9-1b1cc64db490" />

**App in English / TU Attributes**
<img width="914" height="267" alt="image" src="https://github.com/user-attachments/assets/994d4510-9e25-48c4-a87f-3975ed537b54" />

**App in English / Language-specific Attributes**
<img width="887" height="240" alt="image" src="https://github.com/user-attachments/assets/e951055a-6312-43b5-a410-1526071d2e0a" />


