### PR TITLE
Improve French translation of "Enter subscription key" error message

### DIFF
--- a/i18n/tmxeditor_fr.json
+++ b/i18n/tmxeditor_fr.json
@@ -228,13 +228,13 @@
     "selectDifferentLanguages": "Veuillez sélectionner une langue différente"
   },
   "registerNewSubscription": {
-    "enterSubscription": "Saisir la clé de l’abonnement"
+    "enterSubscription": "Veuillez saisir la clé d’abonnement"
   },
   "registerExpired": {
-    "enterSubscription": "Saisir la clé de l’abonnement"
+    "enterSubscription": "Veuillez saisir la clé d’abonnement"
   },
   "registerSubscription": {
-    "enterSubscription": "Saisir la clé de l’abonnement"
+    "enterSubscription": "Veuillez saisir la clé d’abonnement"
   },
   "requestEvaluation": {
     "enterFirstName": "Prénom",


### PR DESCRIPTION
Hello,
Using the official version 3.6.0, I have checked the French translation for the subscription/key part.
I have found one error message poorly translated. This pull request should fix it.

Fix for this issue: https://github.com/japotrad/TMXEditor/issues/8
Best Regards,
Japotrad